### PR TITLE
Allow strftime patterns on datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,21 @@ Use the _-o_ option to designate a target definition file name. The [target](doc
 
 ### Record format
 
-A text file with key names in braces (`{` and `}`) where emitter dimensions will be inserted.
+A text file with key names in braces (`{{` and `}}`) where emitter dimensions will be inserted.
 
 This allows for formats other than JSON to be generated, such as CSV or TSV.
+
+When the key relates to a dimension containing a datetime-type, like `clock` or `timestamp`, you can apply an strftime pattern by using a `|` symbol.  For example, the following will apply an "access_combined"-style date and time format to the `time` dimension:
+
+```
+[{{time|%d/%b/%Y:%H:%M:%S %z}}]
+```
+
+This becomes:
+
+```
+[23/Sep/2023:14:30:00 +0000]
+```
 
 ### Generation limit
 

--- a/conf/form/hec_apache_access_combined.txt
+++ b/conf/form/hec_apache_access_combined.txt
@@ -4,7 +4,7 @@
     "index": "%IEG_INDEX%",
     "host": "{{host}}",
     "time": "{{time}}",
-    "event": "{{clientip}} {{ident}} {{authuser}} [{{time}}] \"{{request_method}} {{request_url}} {{request_protocol}}\" {{status}} {{bytes}} \"{{referrer_url}}\" \"{{useragent}}\"",
+    "event": "{{clientip}} {{ident}} {{authuser}} [{{time|%d/%b/%Y:%H:%M:%S %z}}] \"{{request_method}} {{request_url}} {{request_protocol}}\" {{status}} {{bytes}} \"{{referrer_url}}\" \"{{useragent}}\"",
     "fields": {
         "clientip": "{{clientip}}",
         "ident": "{{ident}}",

--- a/conf/form/tsv_apache_access_combined.txt
+++ b/conf/form/tsv_apache_access_combined.txt
@@ -1,1 +1,1 @@
-{{clientip}} {{ident}} {{authuser}} [{{time}}] "{{request_method}} {{request_url}} {{request_protocol}}" {{status}} {{bytes}} "{{referrer_url}}" "{{useragent}}"
+{{clientip}} {{ident}} {{authuser}} [{{time|%d/%b/%Y:%H:%M:%S %z}}] "{{request_method}} {{request_url}} {{request_protocol}}" {{status}} {{bytes}} "{{referrer_url}}" "{{useragent}}"

--- a/docs/fieldgen.md
+++ b/docs/fieldgen.md
@@ -6,8 +6,8 @@ Whenever a worker encounters a field generator, whether via an emitter dimension
 
 The value that is generated depends on the field generator `type`. Available field generator types are:
 
-* [`clock`](#clock) generates a timestamp using the simulated clock.
-* [`timestamp`](./type-timestamp.md) generates a timestamp between a range.
+* [`clock`](#clock) generates a datetime using the simulated clock.
+* [`timestamp`](./type-timestamp.md) generates a datetime between a range.
 * [`string`](./type-string.md) creates a synthetic string, optionally limited to a specific list of characters.
 * [`int`](./type-int.md) generates whole numbers.
 * [`float`](./type-float.md) generates floating point numbers.
@@ -21,9 +21,20 @@ For information, including examples, see the individual pages for each field gen
 
 #### `clock`
 
-A fundamental field generator, often used for an event timestamp on each row. The value is taken from the clock that runs behind-the-scenes as the generator runs.
+Use the `clock`-type field generator to mimic an event timestamp.
 
-Clock dimensions have the following very simple format:
+Every state machine worker has an internal clock that starts at the time the worker is created by the data generator.
+
+* The very first worker starts either at the current date time, or by using the `-s` argument at the [command line](./command-line.md), at a simulated clock start time.
+* The next output event for that worker is emitted based on the `delay` between `states`. For more information, see [`states`](./genspec-states.md).
+
+The data generator spawns additional workers up to a configurable maximum, e.g. using the `-m` argument at the [command line](./command-line.md). The interval between workers being spawned is controlled by the `interarrival` time, set in the [generator specification](./genspec.md).
+
+```bash
+python3 src/generator.py -f example.json -n 10 -m 1
+```
+
+Clock dimensions have the following structure:
 
 ```
 {
@@ -80,6 +91,10 @@ Object field generators create nested data.
           "cardinality": 0,
           "dimensions": [
             {
+              "type": "clock",
+              "name": "__time"
+            },
+            {
               "type": "enum",
               "name": "enum_dim",
               "values": ["A", "B", "C"],
@@ -127,6 +142,10 @@ Object field generators create nested data.
           "cardinality": 3,
           "cardinality_distribution": { "type": "uniform", "min": 0, "max": 2 },
           "dimensions": [
+            {
+              "type": "clock",
+              "name": "__time"
+            },
             {
               "type": "enum",
               "name": "enum_dim",

--- a/docs/genspec-emitters.md
+++ b/docs/genspec-emitters.md
@@ -11,31 +11,8 @@ Each emitter has this structure:
 | `name` | The unique name for the emitter. | | Yes |
 | `dimensions` | A list of attributes and measures, and, for each, the specification for how data will be generated. | | Yes |
 
-When an event is emitted by a worker, it is made up of:
+Use the `dimensions` list to prescribe the event timestamp, attributes, and measures for each record created by a worker as it enters each state.
 
-* An [event timestamp](#event-timestamps) with the name `time`, generated automatically by the worker.
-* [Attributes and measures](#event-dimensions) set by `dimensions`.
-
-### Event timestamps
-
-A dimension called `time`, containing the synthetic event datetime stamp, is always emitted in ISO format.
-
-Every worker has a different start time depending on when the worker is created by the data generator.
-
-The very first worker starts either at the current date time, or by using the `-s` argument at the [command line](./command-line.md), at a simulated clock start time.
-
-The next output event for that worker is emitted based on the `delay` between `states`. For more information, see [`states`](./genspec-states.md).
-
-The data generator spawns additional workers up to a configurable maximum, e.g. using the `-m` argument at the [command line](./command-line.md). The interval between workers being spawned is controlled by the `interarrival` time, set in the [generator specification](./genspec.md).
-
-```bash
-python3 src/generator.py -f example.json -n 10 -m 1
-```
-
-### Event dimensions
-
-The `dimensions` list prescribes the attributes and measures to be added to the event that is emitted.
-
-The list is made up of [field generators](./fieldgen.md) and, optionally, [worker variables](./type-variable.md).
+The `dimensions` list is made up of [field generators](./fieldgen.md) and, optionally, [worker variables](./type-variable.md).
 
 To understand how to create worker variables, see [states](./genspec-states.md).

--- a/ieg/dimensions.py
+++ b/ieg/dimensions.py
@@ -1,7 +1,7 @@
 import random
 import string
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from ieg.distributions import parse_distribution, parse_timestamp_distribution
 
 #
@@ -249,7 +249,10 @@ class DimensionTimestampClock:
 
     def get_stochastic_value(self):
         # Retrieve the current time from the Clock instance
-        return self.clock.now()
+        current_time = self.clock.now()
+        if current_time.tzinfo is None:
+            current_time = current_time.replace(tzinfo=timezone.utc)  # Default to UTC if no timezone
+        return current_time
 
 class DimensionTimestamp(DimensionBase):
     # Generates random timestamps as datetime objects based on a distribution.
@@ -286,7 +289,10 @@ class DimensionTimestamp(DimensionBase):
 
     def get_stochastic_value(self):
         # Return a random timestamp as a datetime object
-        return datetime.fromtimestamp(self.value_distribution.get_sample())
+        timestamp = datetime.fromtimestamp(self.value_distribution.get_sample())
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)  # Default to UTC if no timezone
+        return timestamp
 
     def get_json_field_string(self):
         if random.random() < self.percent_nulls:


### PR DESCRIPTION
This update allows for strftime patterns to be specified after a bar for fields that have a datetime type. This allows for more flexible output of the date time stamp through a format pattern.

For #5 and #6 .