### PR TITLE
Add IIS output to ecommerce presets

### DIFF
--- a/docs/presets/ecommerce.md
+++ b/docs/presets/ecommerce.md
@@ -17,6 +17,9 @@ python generator.py -c presets/configs/ecommerce.json --template csv -n 1000 -s 
 # With time-of-day variation (schedule modulates the -m cap)
 python generator.py -c presets/configs/ecommerce.json --template access_combined \
   -m 300 -s "2025-01-01T00:00" --schedule presets/schedules/ecommerce.json
+
+# IIS W3C log (Splunk ms:iis:auto sourcetype — recommended)
+python generator.py -c presets/configs/ecommerce.json --template ms:iis:auto -r PT1H -s "2025-01-01T00:00"
 ```
 
 ## Templates
@@ -30,6 +33,12 @@ python generator.py -c presets/configs/ecommerce.json --template access_combined
 | `access_combined_wcookie` | NCSA combined log with cookie field appended |
 | `access_common` | NCSA common log (no referrer or user-agent) |
 | `csv` | CSV with header row |
+| `ms:iis:auto` | IIS W3C log (`ms:iis:auto` sourcetype) |
+| `ms:iis:default:85` | IIS W3C log (`ms:iis:default:85` sourcetype — identical output to `ms:iis:auto`, included for completeness) |
+| `ms:iis:default` | IIS W3C log (`ms:iis:default` sourcetype, IIS 7.0 field ordering) |
+| `ms:iis:splunk` | IIS W3C log (`ms:iis:splunk` sourcetype, adds `Content-Type` and `https` fields) |
+
+When generating IIS data for Splunk, use `--template ms:iis:auto` — the other IIS templates are included for completeness but have been marked as deprecated by Splunk.
 
 ## Output fields
 

--- a/docs/presets/ecommerce_furniture.md
+++ b/docs/presets/ecommerce_furniture.md
@@ -17,6 +17,9 @@ python generator.py -c presets/configs/ecommerce_furniture.json --template csv -
 # With time-of-day variation
 python generator.py -c presets/configs/ecommerce_furniture.json --template access_combined \
   -m 200 --schedule presets/schedules/ecommerce.json
+
+# IIS W3C log (Splunk ms:iis:auto sourcetype — recommended)
+python generator.py -c presets/configs/ecommerce_furniture.json --template ms:iis:auto -r PT1H -s "2025-01-01T00:00"
 ```
 
 ## Templates
@@ -30,6 +33,12 @@ python generator.py -c presets/configs/ecommerce_furniture.json --template acces
 | `access_combined_wcookie` | NCSA combined log with cookie field appended |
 | `access_common` | NCSA common log (no referrer or user-agent) |
 | `csv` | CSV with header row |
+| `ms:iis:auto` | IIS W3C log (`ms:iis:auto` sourcetype) |
+| `ms:iis:default:85` | IIS W3C log (`ms:iis:default:85` sourcetype — identical output to `ms:iis:auto`, included for completeness) |
+| `ms:iis:default` | IIS W3C log (`ms:iis:default` sourcetype, IIS 7.0 field ordering) |
+| `ms:iis:splunk` | IIS W3C log (`ms:iis:splunk` sourcetype, adds `Content-Type` and `https` fields) |
+
+When generating IIS data for Splunk, use `--template ms:iis:auto` — the other IIS templates are included for completeness but have been marked as deprecated by Splunk.
 
 ## Output fields
 

--- a/docs/presets/ecommerce_lighting.md
+++ b/docs/presets/ecommerce_lighting.md
@@ -17,6 +17,9 @@ python generator.py -c presets/configs/ecommerce_lighting.json --template csv -n
 # With time-of-day variation
 python generator.py -c presets/configs/ecommerce_lighting.json --template access_combined \
   -m 500 --schedule presets/schedules/ecommerce.json
+
+# IIS W3C log (Splunk ms:iis:auto sourcetype — recommended)
+python generator.py -c presets/configs/ecommerce_lighting.json --template ms:iis:auto -r PT1H -s "2025-01-01T00:00"
 ```
 
 ## Templates
@@ -30,6 +33,12 @@ python generator.py -c presets/configs/ecommerce_lighting.json --template access
 | `access_combined_wcookie` | NCSA combined log with cookie field appended |
 | `access_common` | NCSA common log (no referrer or user-agent) |
 | `csv` | CSV with header row |
+| `ms:iis:auto` | IIS W3C log (`ms:iis:auto` sourcetype) |
+| `ms:iis:default:85` | IIS W3C log (`ms:iis:default:85` sourcetype — identical output to `ms:iis:auto`, included for completeness) |
+| `ms:iis:default` | IIS W3C log (`ms:iis:default` sourcetype, IIS 7.0 field ordering) |
+| `ms:iis:splunk` | IIS W3C log (`ms:iis:splunk` sourcetype, adds `Content-Type` and `https` fields) |
+
+When generating IIS data for Splunk, use `--template ms:iis:auto` — the other IIS templates are included for completeness but have been marked as deprecated by Splunk.
 
 ## Output fields
 

--- a/presets/configs/ecommerce.json
+++ b/presets/configs/ecommerce.json
@@ -21,6 +21,22 @@
     "csv": {
       "header": "time,bytes_in,bytes_out,cookie,server,dest_port,http_content_type,http_method,http_referrer,http_user_agent,ident,response_time_microseconds,client,status,uri_path,uri_query,user",
       "body": "{{ time.timestamp()|int }},{{ bytes_in }},{{ bytes_out }},\"{{ cookie }}\",\"{{ server }}\",{{ dest_port }},\"{{ http_content_type }}\",\"{{ http_method }}\",\"{{ http_referrer }}\",\"{{ http_user_agent }}\",\"{{ ident }}\",{{ response_time_microseconds }},{{ client }},{{ status }},\"{{ uri_path }}\",\"{{ uri_query }}\",\"{{ user }}\""
+    },
+    "ms:iis:auto": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default:85": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default": {
+      "header": "#Fields: date time cs-uri-stem cs-uri-query s-contentpath sc-status s-computername cs(Referer) sc-win32-status sc-bytes cs-bytes TimeTakenMS s-sitename s-ip s-port RequestsPerSecond cs-host c-ip cs-version c-protocol cs-method CPU-Utilization W3WP-PrivateBytes cs-username cs(User-Agent) time-local sc-substatus s-proxy date-local cs(Cookie)",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} - {{ status }} WEB-SERVER {{ http_referrer }} 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} W3SVC1 {{ server }} {{ dest_port }} - {{ server }} {{ client }} {{ http_version }} - {{ http_method }} - - {{ user }} {{ http_user_agent|replace(' ', '+') }} - 0 - - {{ cookie }}"
+    },
+    "ms:iis:splunk": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken X-Forwarded-For Content-Type https",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} - {{ http_content_type }} {% if dest_port == '443' %}https{% else %}-{% endif %}"
     }
   },
   "emitters": [

--- a/presets/configs/ecommerce_furniture.json
+++ b/presets/configs/ecommerce_furniture.json
@@ -21,6 +21,22 @@
     "csv": {
       "header": "time,bytes_in,bytes_out,cookie,server,dest_port,http_content_type,http_method,http_referrer,http_user_agent,ident,response_time_microseconds,client,status,uri_path,uri_query,user",
       "body": "{{ time.timestamp()|int }},{{ bytes_in }},{{ bytes_out }},\"{{ cookie }}\",\"{{ server }}\",{{ dest_port }},\"{{ http_content_type }}\",\"{{ http_method }}\",\"{{ http_referrer }}\",\"{{ http_user_agent }}\",\"{{ ident }}\",{{ response_time_microseconds }},{{ client }},{{ status }},\"{{ uri_path }}\",\"{{ uri_query }}\",\"{{ user }}\""
+    },
+    "ms:iis:auto": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default:85": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default": {
+      "header": "#Fields: date time cs-uri-stem cs-uri-query s-contentpath sc-status s-computername cs(Referer) sc-win32-status sc-bytes cs-bytes TimeTakenMS s-sitename s-ip s-port RequestsPerSecond cs-host c-ip cs-version c-protocol cs-method CPU-Utilization W3WP-PrivateBytes cs-username cs(User-Agent) time-local sc-substatus s-proxy date-local cs(Cookie)",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} - {{ status }} WEB-SERVER {{ http_referrer }} 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} W3SVC1 {{ server }} {{ dest_port }} - {{ server }} {{ client }} {{ http_version }} - {{ http_method }} - - {{ user }} {{ http_user_agent|replace(' ', '+') }} - 0 - - {{ cookie }}"
+    },
+    "ms:iis:splunk": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken X-Forwarded-For Content-Type https",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} - {{ http_content_type }} {% if dest_port == '443' %}https{% else %}-{% endif %}"
     }
   },
   "emitters": [

--- a/presets/configs/ecommerce_lighting.json
+++ b/presets/configs/ecommerce_lighting.json
@@ -21,6 +21,22 @@
     "csv": {
       "header": "time,bytes_in,bytes_out,cookie,server,dest_port,http_content_type,http_method,http_referrer,http_user_agent,ident,response_time_microseconds,client,status,uri_path,uri_query,user",
       "body": "{{ time.timestamp()|int }},{{ bytes_in }},{{ bytes_out }},\"{{ cookie }}\",\"{{ server }}\",{{ dest_port }},\"{{ http_content_type }}\",\"{{ http_method }}\",\"{{ http_referrer }}\",\"{{ http_user_agent }}\",\"{{ ident }}\",{{ response_time_microseconds }},{{ client }},{{ status }},\"{{ uri_path }}\",\"{{ uri_query }}\",\"{{ user }}\""
+    },
+    "ms:iis:auto": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default:85": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }}"
+    },
+    "ms:iis:default": {
+      "header": "#Fields: date time cs-uri-stem cs-uri-query s-contentpath sc-status s-computername cs(Referer) sc-win32-status sc-bytes cs-bytes TimeTakenMS s-sitename s-ip s-port RequestsPerSecond cs-host c-ip cs-version c-protocol cs-method CPU-Utilization W3WP-PrivateBytes cs-username cs(User-Agent) time-local sc-substatus s-proxy date-local cs(Cookie)",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} - {{ status }} WEB-SERVER {{ http_referrer }} 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} W3SVC1 {{ server }} {{ dest_port }} - {{ server }} {{ client }} {{ http_version }} - {{ http_method }} - - {{ user }} {{ http_user_agent|replace(' ', '+') }} - 0 - - {{ cookie }}"
+    },
+    "ms:iis:splunk": {
+      "header": "#Fields: date time s-sitename s-computername s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs-version cs(User-Agent) cs(Cookie) cs(Referer) cs-host sc-status sc-substatus sc-win32-status sc-bytes cs-bytes time-taken X-Forwarded-For Content-Type https",
+      "body": "{{ time.strftime('%Y-%m-%d') }} {{ time.strftime('%H:%M:%S') }} W3SVC1 WEB-SERVER {{ server }} {{ http_method }} {{ uri_path }} {% if uri_query %}{{ uri_query }}{% else %}-{% endif %} {{ dest_port }} {{ user }} {{ client }} {{ http_version }} {{ http_user_agent|replace(' ', '+') }} {{ cookie }} {{ http_referrer }} {{ server }} {{ status }} 0 0 {{ bytes_out }} {{ bytes_in }} {{ (response_time_microseconds / 1000)|int }} - {{ http_content_type }} {% if dest_port == '443' %}https{% else %}-{% endif %}"
     }
   },
   "emitters": [


### PR DESCRIPTION
The e-commerce presets, while mimicking web servers, only output to Apache-type server formats.

This is because of the limited number of templates available in each configuration.

This PR adds Jinja2 templates that mimic various standards of IIS output.